### PR TITLE
Fix `function-no-unknown` false negatives for functions with namespace

### DIFF
--- a/src/rules/function-no-unknown/__tests__/index.js
+++ b/src/rules/function-no-unknown/__tests__/index.js
@@ -111,7 +111,7 @@ testRule({
       code: "a { color: color.unknown(#6b717f, $red: 15); }",
       message: messages.rejected("color.unknown"),
       line: 1,
-      column: 18
+      column: 12
     },
     {
       code: `
@@ -123,7 +123,7 @@ testRule({
       `,
       message: messages.rejected("othermodule.myfunction"),
       line: 5,
-      column: 31,
+      column: 19,
       description: "non-matching @use namespace"
     },
     {
@@ -136,7 +136,7 @@ testRule({
       `,
       message: messages.rejected("c.myfunction"),
       line: 5,
-      column: 21,
+      column: 19,
       description: "non-matching @use namespace, 'as' keyword"
     },
     {


### PR DESCRIPTION
Since Stylelint 15.8.0, the built-in `function-no-unknown` rule has ignored SCSS functions with namespace.

For example, the following code unexpectedly passes with Stylelint 15.8.0:

```scss
a { color: color.unknown(#fff); }
```

Notes:
- This change keeps backward compatibility. This means not to change `peerDependencies.stylelint` in `package.json`.
- This change may bring performance penalty to keep backward compatibility.
- Run `npm i 'stylelint@^15.8.0' && npm t` to test this change with newer versions of Stylelint.

See also:
- https://github.com/stylelint/stylelint/releases/tag/15.8.0
- https://github.com/stylelint/stylelint/pull/6921

---

This Pull Request should resolve the CI failure in PR #873.
